### PR TITLE
Add price-based gain calculator and current price integration

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 
-from app.routers import auth, redis, users, rpc_node, investigations, background_tasks
+from app.routers import auth, redis, users, rpc_node, investigations, background_tasks, price
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -12,6 +12,8 @@ app.include_router(users.router, tags=["users"])
 app.include_router(rpc_node.router, tags=["rpc_node"])
 app.include_router(redis.router, tags=["redis"])
 app.include_router(investigations.router)
+
+app.include_router(price.router, tags=["price"])
 
 app.include_router(background_tasks.router, tags=["Background Tasks"])
 

--- a/backend/app/routers/price.py
+++ b/backend/app/routers/price.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.auth.dependencies import get_current_active_user
+from app.utils.mempool_api import mempool_api_call
+from app.utils.redis_service import RedisService, get_redis_service
+
+router = APIRouter(prefix="/price")
+
+@router.get("/current", response_model=dict)
+async def get_current_price(
+        current_user: dict = Depends(get_current_active_user),
+        redis_service: RedisService = Depends(get_redis_service),
+):
+    current_price = await mempool_api_call("/api/v1/prices")
+    return current_price
+
+
+@router.get("/historical", response_model=dict)
+async def get_historical_price(
+        timestamp: int,
+        current_user: dict = Depends(get_current_active_user),
+        redis_service: RedisService = Depends(get_redis_service),
+):
+    price = await mempool_api_call(f"api/v1/historical-price?currency=EUR&timestamp={timestamp}")
+    if not price:
+        raise HTTPException(
+            status_code=404, detail=f"Price for timestamp {timestamp} not found."
+        )
+
+    return price

--- a/backend/app/routers/rpc_node.py
+++ b/backend/app/routers/rpc_node.py
@@ -673,17 +673,3 @@ async def get_basic_wallet_info(
 
         except Exception as e:
             raise HTTPException(status_code=500, detail=str(e))
-
-@router.get("/price/historical", response_model=dict)
-async def get_historical_price(
-        timestamp: int,
-        current_user: dict = Depends(get_current_active_user),
-        redis_service: RedisService = Depends(get_redis_service),
-):
-    price = await mempool_api_call(f"api/v1/historical-price?currency=EUR&timestamp={timestamp}")
-    if not price:
-        raise HTTPException(
-            status_code=404, detail=f"Price for timestamp {timestamp} not found."
-        )
-
-    return price

--- a/frontend/app/api/current-price/route.ts
+++ b/frontend/app/api/current-price/route.ts
@@ -1,0 +1,36 @@
+import { getBearerTokenFromHeaders } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000';
+
+export async function GET() {
+    try {
+        const token = await getBearerTokenFromHeaders();
+
+        const response = await fetch(
+            `${BACKEND_URL}/price/current`,
+            {
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            }
+        );
+
+        const data = await response.json();
+
+        if (!response.ok) {
+            return NextResponse.json(
+                { detail: data.detail || 'Failed to fetch node information' },
+                { status: response.status }
+            );
+        }
+
+        return NextResponse.json(data);
+    } catch (error: unknown) {
+        console.error('Node info fetch error:', error);
+        return NextResponse.json(
+            { detail: 'Internal server error' },
+            { status: 500 }
+        );
+    }
+}

--- a/frontend/components/PriceBasedGainCalculator/PriceBasedGainCalculator.tsx
+++ b/frontend/components/PriceBasedGainCalculator/PriceBasedGainCalculator.tsx
@@ -1,0 +1,68 @@
+import {useHistoricalPrices} from "@/hooks/useHistoricalPrices";
+import {CoinAgeResponse} from "@/types/coinAgeData.types";
+import {calculateRealizedGain} from "@/utils/calculateRealizedGain";
+
+interface PriceBasedGainCalculatorProps {
+    coinAgeDetail: CoinAgeResponse["coin_age_details"][0];
+    blockToTimestampMap?: Record<number, number>;
+    currentPrice?: number; // Add current price for unrealized gains
+    isRealized?: boolean;  // Flag to determine if this is a realized gain
+}
+
+export default function PriceBasedGainCalculator({
+                                                     coinAgeDetail,
+                                                     blockToTimestampMap,
+                                                     currentPrice,
+                                                     isRealized = true
+                                                 }: PriceBasedGainCalculatorProps) {
+    const receivedTimestamp = blockToTimestampMap?.[coinAgeDetail.received_block] ||
+        (coinAgeDetail.received_block * 600 + 1230768000).toString();
+
+    const spentTimestamp = isRealized
+        ? (blockToTimestampMap?.[coinAgeDetail.spent_block] ||
+            (coinAgeDetail.spent_block * 600 + 1230768000).toString())
+        : null;
+
+    const {priceData: receivedPriceData} = useHistoricalPrices(receivedTimestamp?.toString());
+    const {priceData: spentPriceData} = isRealized
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        ? useHistoricalPrices(spentTimestamp?.toString())
+        : {priceData: null};
+
+    if (receivedPriceData?.prices &&
+        receivedPriceData.prices.length > 0 &&
+        coinAgeDetail.amount) {
+
+        const acquisitionPrice = receivedPriceData.prices[0].EUR;
+        let sellingPrice;
+
+        if (isRealized && spentPriceData?.prices && spentPriceData.prices.length > 0) {
+            // Use historical selling price for realized gains
+            sellingPrice = spentPriceData.prices[0].EUR;
+        } else {
+            // Use current price for unrealized gains
+            sellingPrice = currentPrice;
+        }
+
+        if (sellingPrice) {
+            const {realizedGain, percentageGain} = calculateRealizedGain(
+                coinAgeDetail.amount,
+                acquisitionPrice,
+                sellingPrice
+            );
+
+            const gainColor = realizedGain >= 0 ? "text-green-500" : "text-red-500";
+
+            return (
+                <div className="mt-1">
+                    <span className={gainColor}>
+                        {realizedGain > 0 ? "+" : ""}${Math.abs(realizedGain).toFixed(2)} ({percentageGain.toFixed(2)}%)
+                        {!isRealized && <span className="text-xs ml-1">(unrealized)</span>}
+                    </span>
+                </div>
+            );
+        }
+    }
+
+    return null;
+}

--- a/frontend/components/TransactionFlow/TransactionFlow.tsx
+++ b/frontend/components/TransactionFlow/TransactionFlow.tsx
@@ -6,7 +6,6 @@ import {MempoolTransaction} from "@/types/transactions.types";
 import Link from "next/link";
 
 export function TransactionFlow({txData}: { txData: MempoolTransaction }) {
-    console.log(txData);
     return (
         <Card>
             <CardHeader>

--- a/frontend/hooks/useCurrentPrice.ts
+++ b/frontend/hooks/useCurrentPrice.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react';
+import {getCookie} from "cookies-next";
+import {CurrentPrice} from "@/types/currentPrice.types";
+
+export function useCurrentPrice(timestamp?: string) {
+    const [priceData, setPriceData] = useState<CurrentPrice>();
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        const fetchPriceData = async () => {
+
+            setError(null);
+            setIsLoading(true);
+            try {
+                const token = getCookie("token") || localStorage.getItem("token");
+
+                const response: Response = await fetch(`/api/current-price`, {
+                    headers: {
+                        'Authorization': `Bearer ${token}`,
+                    },
+                });
+                if (!response.ok) {
+                    throw new Error('Failed to fetch price data');
+                }
+                const data = await response.json();
+                setPriceData(data);
+            } catch (err) {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-expect-error
+                setError(err);
+                console.error('Error fetching price data:', err);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchPriceData();
+    }, [timestamp]);
+
+    return { priceData, isLoading, error };
+}

--- a/frontend/hooks/useWalletInsightFetcher.ts
+++ b/frontend/hooks/useWalletInsightFetcher.ts
@@ -12,7 +12,6 @@ export function useWalletInsightFetcher(input: string, isTxid: boolean) {
         async (type: 'wallet' | 'wallettx') => {
             if (!input) return;
 
-            console.log("wallet address:" + input);
             // Only proceed if isTxid is false (meaning it's a wallet address)
             if (isTxid) return;
 

--- a/frontend/types/currentPrice.types.ts
+++ b/frontend/types/currentPrice.types.ts
@@ -1,0 +1,9 @@
+export type CurrentPrice = {
+    time: number,
+    USD: number,
+    EUR: number,
+    GBP: number,
+    CAD: number,
+    CHF: number,
+    JPY: number,
+}

--- a/frontend/utils/calculateRealizedGain.ts
+++ b/frontend/utils/calculateRealizedGain.ts
@@ -1,0 +1,18 @@
+export function calculateRealizedGain(
+    amount: number,
+    acquisitionPriceUSD: number,
+    sellingPriceUSD: number
+): {
+    realizedGain: number;
+    percentageGain: number;
+} {
+    const acquisitionValue = acquisitionPriceUSD * amount;
+    const sellingValue = sellingPriceUSD * amount;
+    const realizedGain = sellingValue - acquisitionValue;
+    const percentageGain = (realizedGain / acquisitionValue) * 100;
+
+    return {
+        realizedGain,
+        percentageGain
+    };
+}

--- a/frontend/utils/transactionValueFetcher.ts
+++ b/frontend/utils/transactionValueFetcher.ts
@@ -1,13 +1,17 @@
 export const getWalletAmount = (tx: any, address: string) => {
+    // Make sure vout exists and is an array
+    const vout = Array.isArray(tx.vout) ? tx.vout : [];
+    const vin = Array.isArray(tx.vin) ? tx.vin : [];
+
     // Find vout entries that belong to this wallet address
-    const receivedOutputs = tx.vout
-        .filter((output: any) => output.scriptpubkey_address === address)
-        .reduce((sum: number, output: any) => sum + output.value, 0);
+    const receivedOutputs = vout
+        .filter((output: any) => output?.scriptpubkey_address === address)
+        .reduce((sum: number, output: any) => sum + (output.value || 0), 0);
 
     // Find vin entries that came from this wallet address
-    const sentInputs = tx.vin
-        .filter((input: any) => input.prevout?.scriptpubkey_address === address)
-        .reduce((sum: number, input: any) => sum + input.prevout.value, 0);
+    const sentInputs = vin
+        .filter((input: any) => input?.prevout?.scriptpubkey_address === address)
+        .reduce((sum: number, input: any) => sum + (input.prevout?.value || 0), 0);
 
     // Amount held is received - sent
     return receivedOutputs - sentInputs;


### PR DESCRIPTION
This commit introduces a new `PriceBasedGainCalculator` component for calculating realized and unrealized gains, utilizing historical and current price data. Added a new endpoint `/price/current` to fetch live price data from the backend, along with updated hooks and utilities to support these features. Additionally, minor refactoring was done to improve transaction value fetching and remove redundant console logs.